### PR TITLE
Add unit test setup for create_features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,22 @@ To set up the project locally, follow these steps:
 
    ```bash
    git clone https://github.com/Preksha-0211/Weather_Prediction.git
+   ```
 
-2. Navigate to the Project Directory:
+2. **Navigate to the Project Directory**:
 
    ```bash
    cd Weather_Prediction
+   ```
 
-3. Install Dependencies:
+3. **Install Dependencies**:
 
-  ```bash
-  pip install -r requirements.txt
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Run Tests**:
+
+   ```bash
+   pytest
+   ```

--- a/features.py
+++ b/features.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+def create_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Create time series features based on the DataFrame index."""
+    df = df.copy()
+    df['hour'] = df.index.hour
+    df['month'] = df.index.month
+    df['year'] = df.index.year
+    df['dayofmonth'] = df.index.day
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+pytest

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from features import create_features
+
+def test_create_features_columns_exist():
+    df = pd.DataFrame({"temp": [1, 2]}, index=pd.to_datetime(["2021-01-01 00:00", "2021-01-01 01:00"]))
+    result = create_features(df)
+    for col in ["hour", "month", "year", "dayofmonth"]:
+        assert col in result.columns
+


### PR DESCRIPTION
## Summary
- add `create_features` helper as a module
- create unit tests for feature columns
- document test execution and dependencies

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a5978956c832bb1ab424e0f4304ef