### PR TITLE
Add pytest tests and prediction script

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+
+def load_data(path="submission.csv"):
+    """Load predictions file and return DataFrame."""
+    return pd.read_csv(path)
+
+
+def predict():
+    df = load_data()
+    mean_value = df[df.columns[0]].mean()
+    print(f"Mean prediction: {mean_value}")
+
+
+if __name__ == "__main__":
+    predict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 missingno
 scipy
 numpy
+pytest

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,0 +1,6 @@
+from predict import load_data
+
+
+def test_data_loads():
+    df = load_data()
+    assert not df.empty

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+
+def test_prediction_output():
+    result = subprocess.run([sys.executable, 'predict.py'], capture_output=True, text=True)
+    assert result.stdout.strip() != ''


### PR DESCRIPTION
## Summary
- add a simple `predict.py` script for computing the mean prediction
- add `tests/` with basic data loading and prediction tests
- include `pytest` in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a64a3063c832ba3445d9468177614